### PR TITLE
fix LinksUpdate namespace exception, READ_LATEST bug

### DIFF
--- a/src/MediaWiki/Hooks/LinksUpdateComplete.php
+++ b/src/MediaWiki/Hooks/LinksUpdateComplete.php
@@ -72,7 +72,7 @@ class LinksUpdateComplete implements HookListener {
 	 *
 	 * @return true
 	 */
-	public function process( LinksUpdate $linksUpdate ) {
+	public function process( \MediaWiki\Deferred\LinksUpdate\LinksUpdate $linksUpdate ) {
 		if ( $this->isReady === false ) {
 			return $this->doAbort();
 		}

--- a/src/MediaWiki/RevisionGuard.php
+++ b/src/MediaWiki/RevisionGuard.php
@@ -52,7 +52,7 @@ class RevisionGuard {
 	public function isSkippableUpdate( Title $title, &$latestRevID = null ) {
 		// MW 1.34+
 		// https://github.com/wikimedia/mediawiki/commit/b65e77a385c7423ce03a4d21c141d96c28291a60
-		if ( defined( 'Title::READ_LATEST' ) && Title::GAID_FOR_UPDATE == 512 ) {
+		if ( defined( 'Title::READ_LATEST' ) ) {
 			$flag = Title::READ_LATEST;
 		} else {
 			$flag = Title::GAID_FOR_UPDATE;
@@ -81,7 +81,7 @@ class RevisionGuard {
 	public function getLatestRevID( Title $title ) {
 		// MW 1.34+
 		// https://github.com/wikimedia/mediawiki/commit/b65e77a385c7423ce03a4d21c141d96c28291a60
-		if ( defined( 'Title::READ_LATEST' ) && Title::GAID_FOR_UPDATE == 512 ) {
+		if ( defined( 'Title::READ_LATEST' ) ) {
 			$flag = Title::READ_LATEST;
 		} else {
 			$flag = Title::GAID_FOR_UPDATE;


### PR DESCRIPTION
I ran into these bugs while trying to figure out why property values were not propagating.

- `READ_LATEST` bug: no link to an issue, but I ran into this when running `php rebuildData.php --revision-mode`
- `LinksUpdate` bug: https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5708
